### PR TITLE
Publically export FuncArgMod

### DIFF
--- a/src/func.rs
+++ b/src/func.rs
@@ -38,8 +38,8 @@ pub struct FunctionCall {
 }
 
 #[derive(Debug, Default, Copy, Clone, PartialEq)]
-pub(crate) struct FuncArgMod {
-    pub(crate) distinct: bool,
+pub struct FuncArgMod {
+    pub distinct: bool,
 }
 
 impl FunctionCall {
@@ -84,6 +84,10 @@ impl FunctionCall {
 
     pub fn get_args(&self) -> &[SimpleExpr] {
         &self.args
+    }
+
+    pub fn get_mods(&self) -> &[FuncArgMod] {
+        &self.mods
     }
 }
 


### PR DESCRIPTION
I'm using `main-fork` here as our primary fork branch so we can integrate multiple changes w/o disrupting master